### PR TITLE
Uniform get-raw-link() naming

### DIFF
--- a/lib/OpenAPI/Model/OpenAPI.pm6
+++ b/lib/OpenAPI/Model/OpenAPI.pm6
@@ -1258,7 +1258,8 @@ class OpenAPI::Model::Response does OpenAPI::Model::Element[
     method get-header(Str $id) { self!resolve(%!headers{$id}, expect => OpenAPI::Model::Header) }
     method get-raw-header(Str $id) { %!headers{$id} }
     method get-link(Str $id) { self!resolve(%!links{$id}, expect => OpenAPI::Model::Link) }
-    method raw-get-link(Str $id) { %!links{$id} }
+    method raw-get-link(Str $id) is DEPRECATED('get-raw-link') { %!links{$id} } # TODO will be removed in 1.2
+    method get-raw-link(Str $id) { %!links{$id} }
 
     # Setters
     #| Adds header into response by id.

--- a/t/00-openapi-model.t
+++ b/t/00-openapi-model.t
@@ -109,7 +109,7 @@ $api.paths.delete-path('/pets');
 ok $api.paths.kv.elems == 0, 'Path was removed';
 $api.paths.set-path('/pets', $path);
 ok $api.paths.kv.elems == 2, 'Path was set for Paths object';
-ok $api.paths.pairs ~~ Seq, 'paris methods returns Seq';
+ok $api.paths.pairs ~~ Seq, 'pairs methods returns Seq';
 ok $api.paths.pairs.elems == 1, 'Paths Object has correct number of elements from pairs';
 my $pair = $api.paths.pairs.first;
 ok $pair ~~ Pair, 'Got correct pair from pairs';

--- a/t/05-references.t
+++ b/t/05-references.t
@@ -94,7 +94,7 @@ is $api.serialize, from-json($json-doc), 'Serialization works';
 my $link1 = $api.paths</2.0/repositories/{username}>.get.responses<200>.links<userRepository>;
 my $link2 = $api.paths</2.0/repositories/{username}>.get.responses<200>.get-link('userRepository');
 
-my $ref = $api.paths</2.0/repositories/{username}>.get.responses<200>.raw-get-link('userRepository');
+my $ref = $api.paths</2.0/repositories/{username}>.get.responses<200>.get-raw-link('userRepository');
 
 ok $link1 !~~ OpenAPI::Model::Reference, 'AT-KEY gives resolved link';
 ok $link2 !~~ OpenAPI::Model::Reference, 'get-link gives resolved link';


### PR DESCRIPTION
The raw link method is once called `get-raw-link` and once `raw-get-link`. Change the names to be uniform. This is a breaking change. Not sure how bad it actually is.
Also fix a typo.